### PR TITLE
Hide temp forms after submission and clarify Celsius input

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,10 +63,17 @@ def location_page(location_id):
 def cooler_page(cooler_id):
     db = get_db()
     cooler = db.execute('SELECT * FROM cooler WHERE id=?', (cooler_id,)).fetchone()
+    today = datetime.utcnow().date().isoformat()
+    logs = db.execute(
+        'SELECT shift, temperature, timestamp FROM log WHERE cooler_id=? AND DATE(timestamp)=?',
+        (cooler_id, today)
+    ).fetchall()
+    start_log = next((log for log in logs if log['shift'] == 'start'), None)
+    end_log = next((log for log in logs if log['shift'] == 'end'), None)
     db.close()
     if cooler is None:
         return redirect(url_for('index'))
-    return render_template('cooler.html', cooler=cooler)
+    return render_template('cooler.html', cooler=cooler, start_log=start_log, end_log=end_log)
 
 
 @app.route('/cooler/<int:cooler_id>/submit/<shift>', methods=['POST'])
@@ -77,9 +84,14 @@ def submit_log(cooler_id, shift):
     if not temp or not signature:
         flash('Temperature and signature required.')
         return redirect(url_for('cooler_page', cooler_id=cooler_id))
+    try:
+        temp_val = float(temp)
+    except (TypeError, ValueError):
+        flash('Invalid temperature.')
+        return redirect(url_for('cooler_page', cooler_id=cooler_id))
     db = get_db()
     db.execute('INSERT INTO log (cooler_id, shift, temperature, timestamp, signature) VALUES (?, ?, ?, ?, ?)',
-               (cooler_id, shift, temp, timestamp, signature))
+               (cooler_id, shift, temp_val, timestamp, signature))
     db.commit()
     db.close()
     flash('Temperature saved.')

--- a/templates/cooler.html
+++ b/templates/cooler.html
@@ -5,41 +5,59 @@
 <img src="{{ cooler.image_url }}" alt="{{ cooler.name }}" style="max-width:100%;height:auto;">
 {% endif %}
 
+<p><em>Note: temperatures are recorded in °C and may be positive or negative.</em></p>
+
+{% if not start_log %}
 <h2>Start of Shift</h2>
 <p>Time: <span id="start-time"></span></p>
 <form id="start-form" method="post" action="{{ url_for('submit_log', cooler_id=cooler.id, shift='start') }}">
-  <label>Temperature: <input type="number" step="0.1" name="temperature" required></label><br>
+  <label>Temperature (°C): <input type="number" step="0.1" name="temperature" required></label>
+  <small>Negative values allowed.</small><br>
   <canvas id="start-pad" width="300" height="150"></canvas><br>
   <button type="button" onclick="startPad.clear()">Clear</button>
   <input type="hidden" name="signature" id="start-signature">
   <button type="submit">Submit Start Temp</button>
 </form>
+{% else %}
+<p>Start of shift temperature recorded: {{ start_log['temperature'] }}°C at {{ start_log['timestamp'] }}</p>
+{% endif %}
 
+{% if not end_log %}
 <h2>End of Shift</h2>
 <p>Time: <span id="end-time"></span></p>
 <form id="end-form" method="post" action="{{ url_for('submit_log', cooler_id=cooler.id, shift='end') }}">
-  <label>Temperature: <input type="number" step="0.1" name="temperature" required></label><br>
+  <label>Temperature (°C): <input type="number" step="0.1" name="temperature" required></label>
+  <small>Negative values allowed.</small><br>
   <canvas id="end-pad" width="300" height="150"></canvas><br>
   <button type="button" onclick="endPad.clear()">Clear</button>
   <input type="hidden" name="signature" id="end-signature">
   <button type="submit">Submit End Temp</button>
 </form>
+{% else %}
+<p>End of shift temperature recorded: {{ end_log['temperature'] }}°C at {{ end_log['timestamp'] }}</p>
+{% endif %}
 
 <p><a href="{{ url_for('cooler_qr', cooler_id=cooler.id) }}" target="_blank">Generate QR Code</a></p>
 
 <script src="https://cdn.jsdelivr.net/npm/signature_pad@4.0.0/dist/signature_pad.umd.min.js"></script>
 <script>
-var startPad = new SignaturePad(document.getElementById('start-pad'));
-var endPad = new SignaturePad(document.getElementById('end-pad'));
-document.getElementById('start-time').textContent = new Date().toLocaleString();
-document.getElementById('end-time').textContent = new Date().toLocaleString();
-document.getElementById('start-form').addEventListener('submit', function(e){
-    if (startPad.isEmpty()) { alert('Please provide a signature.'); e.preventDefault(); return; }
-    document.getElementById('start-signature').value = startPad.toDataURL('image/png');
-});
-document.getElementById('end-form').addEventListener('submit', function(e){
-    if (endPad.isEmpty()) { alert('Please provide a signature.'); e.preventDefault(); return; }
-    document.getElementById('end-signature').value = endPad.toDataURL('image/png');
-});
+var startPadElem = document.getElementById('start-pad');
+if (startPadElem) {
+    var startPad = new SignaturePad(startPadElem);
+    document.getElementById('start-time').textContent = new Date().toLocaleString();
+    document.getElementById('start-form').addEventListener('submit', function(e){
+        if (startPad.isEmpty()) { alert('Please provide a signature.'); e.preventDefault(); return; }
+        document.getElementById('start-signature').value = startPad.toDataURL('image/png');
+    });
+}
+var endPadElem = document.getElementById('end-pad');
+if (endPadElem) {
+    var endPad = new SignaturePad(endPadElem);
+    document.getElementById('end-time').textContent = new Date().toLocaleString();
+    document.getElementById('end-form').addEventListener('submit', function(e){
+        if (endPad.isEmpty()) { alert('Please provide a signature.'); e.preventDefault(); return; }
+        document.getElementById('end-signature').value = endPad.toDataURL('image/png');
+    });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Hide start and end shift forms once today's temperature is logged
- Clarify temperature input as Celsius and note negative values allowed
- Validate temperature values server-side

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68af7f0b59508324bf4f4a44a868a9a0