### PR TITLE
Add Bootstrap styling and color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,20 @@ Track the temperature of coolers in multiple locations.
 3. Visit `http://localhost:5000` in your browser.
 
 The default admin password is `admin`. You can override it with the `ADMIN_PASSWORD` environment variable.
+
+## Styling
+
+The app uses [Bootstrap](https://getbootstrap.com/) via CDN for layout and components.
+A cohesive color palette is defined with CSS variables in `static/style.css`:
+
+```css
+:root {
+  --color-primary: #0d6efd;
+  --color-secondary: #6c757d;
+  --color-accent: #198754;
+  --color-bg: #f8f9fa;
+  --color-text: #212529;
+}
+```
+
+Use these variables in custom styles to keep colors consistent across the application.

--- a/static/style.css
+++ b/static/style.css
@@ -1,4 +1,18 @@
-body { font-family: Arial, sans-serif; margin: 20px; }
-nav a { margin-right: 10px; }
-canvas { border: 1px solid #000; }
-form { margin-bottom: 20px; }
+:root {
+  --color-primary: #0d6efd;
+  --color-secondary: #6c757d;
+  --color-accent: #198754;
+  --color-bg: #f8f9fa;
+  --color-text: #212529;
+
+  --bs-primary: var(--color-primary);
+  --bs-secondary: var(--color-secondary);
+  --bs-success: var(--color-accent);
+  --bs-body-bg: var(--color-bg);
+  --bs-body-color: var(--color-text);
+}
+
+body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,28 +3,38 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <title>Temp Tracker</title>
 </head>
 <body>
-<nav>
-    <a href="{{ url_for('index') }}">Home</a>
-    {% if session.get('admin_logged_in') %}
-    <a href="{{ url_for('admin_dashboard') }}">Admin</a>
-    <a href="{{ url_for('admin_logout') }}">Logout</a>
-    {% else %}
-    <a href="{{ url_for('admin_login') }}">Admin Login</a>
-    {% endif %}
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">Temp Tracker</a>
+        <div class="navbar-nav">
+            {% if session.get('admin_logged_in') %}
+            <a class="nav-link" href="{{ url_for('admin_dashboard') }}">Admin</a>
+            <a class="nav-link" href="{{ url_for('admin_logout') }}">Logout</a>
+            {% else %}
+            <a class="nav-link" href="{{ url_for('admin_login') }}">Admin Login</a>
+            {% endif %}
+        </div>
+    </div>
 </nav>
+<div class="container">
 {% with messages = get_flashed_messages() %}
   {% if messages %}
-    <ul>
-    {% for message in messages %}
-      <li>{{ message }}</li>
-    {% endfor %}
-    </ul>
+    <div class="alert alert-info">
+      <ul class="mb-0">
+      {% for message in messages %}
+        <li>{{ message }}</li>
+      {% endfor %}
+      </ul>
+    </div>
   {% endif %}
 {% endwith %}
 {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Integrate Bootstrap via CDN and update base template navigation/layout
- Replace existing CSS with color tokens and variables
- Document styling approach and palette in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af83c433fc8324bdccde3589f29743