### PR TITLE
Add reusable form styles and apply across templates

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2,3 +2,41 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 nav a { margin-right: 10px; }
 canvas { border: 1px solid #000; }
 form { margin-bottom: 20px; }
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+.btn:hover,
+.btn:focus {
+  background-color: #0056b3;
+  outline: none;
+}

--- a/templates/admin/coolers.html
+++ b/templates/admin/coolers.html
@@ -10,15 +10,23 @@
 </ul>
 <h2>Add Cooler</h2>
 <form method="post">
-  <input type="text" name="name" placeholder="Cooler name" required><br>
-  <label>Location:
-    <select name="location_id" required>
-      {% for loc in locations %}
-        <option value="{{ loc.id }}">{{ loc.name }}</option>
-      {% endfor %}
-    </select>
-  </label><br>
-  <input type="text" name="image_url" placeholder="Image URL"><br>
-  <button type="submit">Add</button>
+  <div class="form-group">
+    <input class="input" type="text" name="name" placeholder="Cooler name" required>
+  </div>
+  <div class="form-group">
+    <label>Location:
+      <select class="input" name="location_id" required>
+        {% for loc in locations %}
+          <option value="{{ loc.id }}">{{ loc.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+  </div>
+  <div class="form-group">
+    <input class="input" type="text" name="image_url" placeholder="Image URL">
+  </div>
+  <div class="form-group">
+    <button class="btn" type="submit">Add</button>
+  </div>
 </form>
 {% endblock %}

--- a/templates/admin/locations.html
+++ b/templates/admin/locations.html
@@ -10,7 +10,11 @@
 </ul>
 <h2>Add Location</h2>
 <form method="post">
-  <input type="text" name="name" placeholder="Location name" required>
-  <button type="submit">Add</button>
+  <div class="form-group">
+    <input class="input" type="text" name="name" placeholder="Location name" required>
+  </div>
+  <div class="form-group">
+    <button class="btn" type="submit">Add</button>
+  </div>
 </form>
 {% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -2,8 +2,12 @@
 {% block content %}
 <h1>Admin Login</h1>
 <form method="post">
-  <input type="password" name="password" placeholder="Password" required>
-  <button type="submit">Login</button>
+  <div class="form-group">
+    <input class="input" type="password" name="password" placeholder="Password" required>
+  </div>
+  <div class="form-group">
+    <button class="btn" type="submit">Login</button>
+  </div>
 </form>
 {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
 {% endblock %}

--- a/templates/cooler.html
+++ b/templates/cooler.html
@@ -11,12 +11,20 @@
 <h2>Start of Shift</h2>
 <p>Time: <span id="start-time"></span></p>
 <form id="start-form" method="post" action="{{ url_for('submit_log', cooler_id=cooler.id, shift='start') }}">
-  <label>Temperature (°C): <input type="number" step="0.1" name="temperature" required></label>
-  <small>Negative values allowed.</small><br>
-  <canvas id="start-pad" width="300" height="150"></canvas><br>
-  <button type="button" onclick="startPad.clear()">Clear</button>
+  <div class="form-group">
+    <label>Temperature (°C): <input class="input" type="number" step="0.1" name="temperature" required></label>
+    <small>Negative values allowed.</small>
+  </div>
+  <div class="form-group">
+    <canvas id="start-pad" width="300" height="150"></canvas>
+  </div>
+  <div class="form-group">
+    <button class="btn" type="button" onclick="startPad.clear()">Clear</button>
+  </div>
   <input type="hidden" name="signature" id="start-signature">
-  <button type="submit">Submit Start Temp</button>
+  <div class="form-group">
+    <button class="btn" type="submit">Submit Start Temp</button>
+  </div>
 </form>
 {% else %}
 <p>Start of shift temperature recorded: {{ start_log['temperature'] }}°C at {{ start_log['timestamp'] }}</p>
@@ -26,12 +34,20 @@
 <h2>End of Shift</h2>
 <p>Time: <span id="end-time"></span></p>
 <form id="end-form" method="post" action="{{ url_for('submit_log', cooler_id=cooler.id, shift='end') }}">
-  <label>Temperature (°C): <input type="number" step="0.1" name="temperature" required></label>
-  <small>Negative values allowed.</small><br>
-  <canvas id="end-pad" width="300" height="150"></canvas><br>
-  <button type="button" onclick="endPad.clear()">Clear</button>
+  <div class="form-group">
+    <label>Temperature (°C): <input class="input" type="number" step="0.1" name="temperature" required></label>
+    <small>Negative values allowed.</small>
+  </div>
+  <div class="form-group">
+    <canvas id="end-pad" width="300" height="150"></canvas>
+  </div>
+  <div class="form-group">
+    <button class="btn" type="button" onclick="endPad.clear()">Clear</button>
+  </div>
   <input type="hidden" name="signature" id="end-signature">
-  <button type="submit">Submit End Temp</button>
+  <div class="form-group">
+    <button class="btn" type="submit">Submit End Temp</button>
+  </div>
 </form>
 {% else %}
 <p>End of shift temperature recorded: {{ end_log['temperature'] }}°C at {{ end_log['timestamp'] }}</p>


### PR DESCRIPTION
## Summary
- Add `.form-group`, `.input`, and `.btn` classes with hover/focus styles and spacing
- Apply new form classes throughout admin and cooler templates for consistent styling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af83ceaaf88324a078f7ed48d52c14