### PR TITLE
Style flash messages with alert icons

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,19 +82,19 @@ def submit_log(cooler_id, shift):
     signature = request.form.get('signature')
     timestamp = datetime.utcnow().isoformat()
     if not temp or not signature:
-        flash('Temperature and signature required.')
+        flash('Temperature and signature required.', 'warning')
         return redirect(url_for('cooler_page', cooler_id=cooler_id))
     try:
         temp_val = float(temp)
     except (TypeError, ValueError):
-        flash('Invalid temperature.')
+        flash('Invalid temperature.', 'error')
         return redirect(url_for('cooler_page', cooler_id=cooler_id))
     db = get_db()
     db.execute('INSERT INTO log (cooler_id, shift, temperature, timestamp, signature) VALUES (?, ?, ?, ?, ?)',
                (cooler_id, shift, temp_val, timestamp, signature))
     db.commit()
     db.close()
-    flash('Temperature saved.')
+    flash('Temperature saved.', 'success')
     return redirect(url_for('cooler_page', cooler_id=cooler_id))
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -2,3 +2,34 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 nav a { margin-right: 10px; }
 canvas { border: 1px solid #000; }
 form { margin-bottom: 20px; }
+
+/* Alert styles */
+.alert {
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.alert-icon {
+  margin-right: 8px;
+}
+
+.alert-success {
+  background-color: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.alert-warning {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeeba;
+}
+
+.alert-error {
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,13 +16,16 @@
     <a href="{{ url_for('admin_login') }}">Admin Login</a>
     {% endif %}
 </nav>
-{% with messages = get_flashed_messages() %}
+{% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
-    <ul>
-    {% for message in messages %}
-      <li>{{ message }}</li>
+    {% for category, message in messages %}
+      <div class="alert alert-{{ category }}">
+        <span class="alert-icon">
+          {% if category == 'success' %}✔{% elif category == 'warning' %}⚠{% elif category == 'error' %}✖{% endif %}
+        </span>
+        {{ message }}
+      </div>
     {% endfor %}
-    </ul>
   {% endif %}
 {% endwith %}
 {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- add CSS alert classes for success, warning, and error states
- wrap flashed messages in styled alert divs with icons
- categorize flash messages in submission workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af83d2f504832491a86b0d7c9c12a4