### PR TITLE
Add timezone settings and formatted timestamps

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import io
 import sqlite3
 from datetime import datetime
 from functools import wraps
+import pytz
 
 from flask import (Flask, render_template, request, redirect, url_for,
                    session, send_file, flash)
@@ -17,6 +18,7 @@ app.secret_key = os.environ.get('SECRET_KEY', 'dev')
 def get_db():
     db = sqlite3.connect(app.config['DATABASE'])
     db.row_factory = sqlite3.Row
+    db.execute('CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)')
     return db
 
 
@@ -38,6 +40,19 @@ def admin_required(view):
             return redirect(url_for('admin_login'))
         return view(**kwargs)
     return wrapped_view
+
+
+def get_timezone():
+    db = get_db()
+    row = db.execute("SELECT value FROM settings WHERE key='timezone'").fetchone()
+    db.close()
+    return row['value'] if row else 'UTC'
+
+
+def format_timestamp(ts, tzname):
+    dt = datetime.fromisoformat(ts)
+    dt = pytz.utc.localize(dt).astimezone(pytz.timezone(tzname))
+    return dt.strftime('%H:%M %d/%m/%Y')
 
 
 @app.route('/')
@@ -71,9 +86,16 @@ def cooler_page(cooler_id):
     start_log = next((log for log in logs if log['shift'] == 'start'), None)
     end_log = next((log for log in logs if log['shift'] == 'end'), None)
     db.close()
+    tzname = get_timezone()
+    if start_log:
+        start_log = dict(start_log)
+        start_log['timestamp'] = format_timestamp(start_log['timestamp'], tzname)
+    if end_log:
+        end_log = dict(end_log)
+        end_log['timestamp'] = format_timestamp(end_log['timestamp'], tzname)
     if cooler is None:
         return redirect(url_for('index'))
-    return render_template('cooler.html', cooler=cooler, start_log=start_log, end_log=end_log)
+    return render_template('cooler.html', cooler=cooler, start_log=start_log, end_log=end_log, timezone=tzname)
 
 
 @app.route('/cooler/<int:cooler_id>/submit/<shift>', methods=['POST'])
@@ -195,7 +217,29 @@ def admin_logs():
                           JOIN location ON cooler.location_id = location.id
                           ORDER BY log.timestamp DESC''').fetchall()
     db.close()
-    return render_template('admin/logs.html', logs=logs)
+    tzname = get_timezone()
+    logs = [dict(log) for log in logs]
+    for log in logs:
+        log['timestamp'] = format_timestamp(log['timestamp'], tzname)
+    return render_template('admin/logs.html', logs=logs, timezone=tzname)
+
+
+@app.route('/admin/settings', methods=['GET', 'POST'])
+@admin_required
+def admin_settings():
+    current_tz = get_timezone()
+    if request.method == 'POST':
+        tz = request.form.get('timezone')
+        if tz in pytz.all_timezones:
+            db = get_db()
+            db.execute("REPLACE INTO settings (key, value) VALUES ('timezone', ?)", (tz,))
+            db.commit()
+            db.close()
+            flash('Timezone updated.', 'success')
+            current_tz = tz
+        else:
+            flash('Invalid timezone.', 'error')
+    return render_template('admin/settings.html', timezone=current_tz, timezones=sorted(pytz.all_timezones))
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 qrcode[pil]
+pytz

--- a/schema.sql
+++ b/schema.sql
@@ -20,3 +20,8 @@ CREATE TABLE IF NOT EXISTS log (
     signature TEXT NOT NULL,
     FOREIGN KEY(cooler_id) REFERENCES cooler(id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -5,5 +5,6 @@
   <li><a href="{{ url_for('admin_locations') }}">Manage Locations</a></li>
   <li><a href="{{ url_for('admin_coolers') }}">Manage Coolers</a></li>
   <li><a href="{{ url_for('admin_logs') }}">View Logs</a></li>
+  <li><a href="{{ url_for('admin_settings') }}">Settings</a></li>
 </ul>
 {% endblock %}

--- a/templates/admin/logs.html
+++ b/templates/admin/logs.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1>Temperature Logs</h1>
 <table border="1" cellspacing="0" cellpadding="4">
-<tr><th>Location</th><th>Cooler</th><th>Shift</th><th>Temperature</th><th>Time</th><th>Signature</th></tr>
+<tr><th>Location</th><th>Cooler</th><th>Shift</th><th>Temperature</th><th>Time ({{ timezone }})</th><th>Signature</th></tr>
 {% for log in logs %}
 <tr>
   <td>{{ log.location_name }}</td>

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Settings</h1>
+<form method="post">
+  <div class="mb-3">
+    <label for="timezone" class="form-label">Timezone</label>
+    <select class="form-select" id="timezone" name="timezone">
+      {% for tz in timezones %}
+      <option value="{{ tz }}" {% if tz == timezone %}selected{% endif %}>{{ tz }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% endblock %}
+

--- a/templates/cooler.html
+++ b/templates/cooler.html
@@ -57,10 +57,12 @@
 
 <script src="https://cdn.jsdelivr.net/npm/signature_pad@4.0.0/dist/signature_pad.umd.min.js"></script>
 <script>
+var tz = "{{ timezone }}";
+var opts = {hour:'2-digit', minute:'2-digit', day:'2-digit', month:'2-digit', year:'numeric', timeZone: tz};
 var startPadElem = document.getElementById('start-pad');
 if (startPadElem) {
     var startPad = new SignaturePad(startPadElem);
-    document.getElementById('start-time').textContent = new Date().toLocaleString();
+    document.getElementById('start-time').textContent = new Date().toLocaleString('en-GB', opts);
     document.getElementById('start-form').addEventListener('submit', function(e){
         if (startPad.isEmpty()) { alert('Please provide a signature.'); e.preventDefault(); return; }
         document.getElementById('start-signature').value = startPad.toDataURL('image/png');
@@ -69,7 +71,7 @@ if (startPadElem) {
 var endPadElem = document.getElementById('end-pad');
 if (endPadElem) {
     var endPad = new SignaturePad(endPadElem);
-    document.getElementById('end-time').textContent = new Date().toLocaleString();
+    document.getElementById('end-time').textContent = new Date().toLocaleString('en-GB', opts);
     document.getElementById('end-form').addEventListener('submit', function(e){
         if (endPad.isEmpty()) { alert('Please provide a signature.'); e.preventDefault(); return; }
         document.getElementById('end-signature').value = endPad.toDataURL('image/png');


### PR DESCRIPTION
## Summary
- allow admins to pick the app's timezone via a new settings page
- show log timestamps in HH:MM DD/MM/YYYY format using the configured timezone
- expose timezone selector in admin dashboard and format on cooler pages

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68afb1af94308324bda450daa30c6d0a