### PR TITLE
Enable cooler image uploads and add reporting tools

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,18 +1,21 @@
 import os
 import io
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import wraps
 import pytz
 
 from flask import (Flask, render_template, request, redirect, url_for,
                    session, send_file, flash)
+from werkzeug.utils import secure_filename
 import qrcode
 
 app = Flask(__name__)
 app.config['DATABASE'] = os.path.join(app.root_path, 'app.db')
 app.config['ADMIN_PASSWORD'] = os.environ.get('ADMIN_PASSWORD', 'admin')
 app.secret_key = os.environ.get('SECRET_KEY', 'dev')
+app.config['UPLOAD_FOLDER'] = os.path.join(app.root_path, 'static', 'uploads')
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 
 
 def get_db():
@@ -187,10 +190,15 @@ def admin_coolers():
     if request.method == 'POST':
         name = request.form.get('name')
         location_id = request.form.get('location_id')
-        image_url = request.form.get('image_url')
+        image = request.files.get('image')
+        image_path = None
+        if image and image.filename:
+            filename = secure_filename(image.filename)
+            image.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+            image_path = os.path.join('uploads', filename)
         if name and location_id:
-            db.execute('INSERT INTO cooler (location_id, name, image_url) VALUES (?, ?, ?)',
-                       (location_id, name, image_url))
+            db.execute('INSERT INTO cooler (location_id, name, image_path) VALUES (?, ?, ?)',
+                       (location_id, name, image_path))
             db.commit()
     coolers = db.execute('SELECT cooler.*, location.name as location_name FROM cooler JOIN location ON cooler.location_id = location.id').fetchall()
     db.close()
@@ -223,6 +231,102 @@ def admin_logs():
         log['timestamp'] = format_timestamp(log['timestamp'], tzname)
     return render_template('admin/logs.html', logs=logs, timezone=tzname)
 
+
+@app.route('/admin/reports/averages', methods=['GET', 'POST'])
+@admin_required
+def report_average():
+    db = get_db()
+    locations = db.execute('SELECT * FROM location').fetchall()
+    results = None
+    if request.method == 'POST':
+        start_date = request.form.get('start_date')
+        end_date = request.form.get('end_date')
+        location_id = request.form.get('location_id')
+        query = ('SELECT log.shift, log.temperature, log.timestamp '
+                 'FROM log JOIN cooler ON log.cooler_id = cooler.id '
+                 'WHERE DATE(log.timestamp) BETWEEN ? AND ?')
+        params = [start_date, end_date]
+        if location_id != 'all':
+            query += ' AND cooler.location_id = ?'
+            params.append(location_id)
+        logs = db.execute(query, params).fetchall()
+        tz = pytz.timezone(get_timezone())
+        start_times, start_temps, end_times, end_temps = [], [], [], []
+        for log in logs:
+            dt = datetime.fromisoformat(log['timestamp'])
+            dt_local = pytz.utc.localize(dt).astimezone(tz)
+            seconds = dt_local.hour * 3600 + dt_local.minute * 60 + dt_local.second
+            if log['shift'] == 'start':
+                start_temps.append(log['temperature'])
+                start_times.append(seconds)
+            elif log['shift'] == 'end':
+                end_temps.append(log['temperature'])
+                end_times.append(seconds)
+
+        def avg_time(values):
+            if not values:
+                return 'N/A'
+            avg_sec = sum(values) / len(values)
+            h = int(avg_sec // 3600)
+            m = int((avg_sec % 3600) // 60)
+            return f"{h:02d}:{m:02d}"
+
+        def avg_temp(values):
+            if not values:
+                return 'N/A'
+            return round(sum(values) / len(values), 2)
+
+        results = {
+            'start_time': avg_time(start_times),
+            'start_temp': avg_temp(start_temps),
+            'end_time': avg_time(end_times),
+            'end_temp': avg_temp(end_temps),
+        }
+    db.close()
+    return render_template('admin/report_avg.html', locations=locations, results=results)
+
+
+@app.route('/admin/reports/missed', methods=['GET', 'POST'])
+@admin_required
+def report_missed():
+    db = get_db()
+    locations = db.execute('SELECT * FROM location').fetchall()
+    total = None
+    weekday_counts = None
+    if request.method == 'POST':
+        start_date = request.form.get('start_date')
+        end_date = request.form.get('end_date')
+        location_id = request.form.get('location_id')
+        start_dt = datetime.fromisoformat(start_date).date()
+        end_dt = datetime.fromisoformat(end_date).date()
+        if location_id != 'all':
+            cooler_rows = db.execute('SELECT id FROM cooler WHERE location_id=?', (location_id,)).fetchall()
+            logs = db.execute('''SELECT log.cooler_id, log.shift, DATE(log.timestamp) as d
+                                 FROM log JOIN cooler ON log.cooler_id=cooler.id
+                                 WHERE DATE(log.timestamp) BETWEEN ? AND ? AND cooler.location_id=?''',
+                              (start_date, end_date, location_id)).fetchall()
+        else:
+            cooler_rows = db.execute('SELECT id FROM cooler').fetchall()
+            logs = db.execute('''SELECT log.cooler_id, log.shift, DATE(log.timestamp) as d
+                                 FROM log JOIN cooler ON log.cooler_id=cooler.id
+                                 WHERE DATE(log.timestamp) BETWEEN ? AND ?''',
+                              (start_date, end_date)).fetchall()
+        cooler_ids = [row['id'] for row in cooler_rows]
+        existing = {(row['cooler_id'], row['d'], row['shift']) for row in logs}
+        total = 0
+        weekday_counts = {day: 0 for day in ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']}
+        current = start_dt
+        while current <= end_dt:
+            day_name = current.strftime('%A')
+            d_str = current.isoformat()
+            for cid in cooler_ids:
+                for shift in ('start', 'end'):
+                    if (cid, d_str, shift) not in existing:
+                        total += 1
+                        weekday_counts[day_name] += 1
+            current += timedelta(days=1)
+    db.close()
+    return render_template('admin/report_missed.html', locations=locations, total=total, weekday_counts=weekday_counts)
 
 @app.route('/admin/settings', methods=['GET', 'POST'])
 @admin_required

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS cooler (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     location_id INTEGER NOT NULL,
     name TEXT NOT NULL,
-    image_url TEXT,
+    image_path TEXT,
     FOREIGN KEY(location_id) REFERENCES location(id) ON DELETE CASCADE
 );
 

--- a/templates/admin/coolers.html
+++ b/templates/admin/coolers.html
@@ -9,7 +9,7 @@
   {% endfor %}
 </ul>
 <h2>Add Cooler</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
   <div class="form-group">
     <input class="input" type="text" name="name" placeholder="Cooler name" required>
   </div>
@@ -23,7 +23,7 @@
     </label>
   </div>
   <div class="form-group">
-    <input class="input" type="text" name="image_url" placeholder="Image URL">
+    <input class="input" type="file" name="image">
   </div>
   <div class="form-group">
     <button class="btn" type="submit">Add</button>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -5,6 +5,8 @@
   <li><a href="{{ url_for('admin_locations') }}">Manage Locations</a></li>
   <li><a href="{{ url_for('admin_coolers') }}">Manage Coolers</a></li>
   <li><a href="{{ url_for('admin_logs') }}">View Logs</a></li>
+  <li><a href="{{ url_for('report_average') }}">Average Temp Report</a></li>
+  <li><a href="{{ url_for('report_missed') }}">Missed Temps Report</a></li>
   <li><a href="{{ url_for('admin_settings') }}">Settings</a></li>
 </ul>
 {% endblock %}

--- a/templates/admin/report_avg.html
+++ b/templates/admin/report_avg.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Average Temperature Report</h1>
+<form method="post">
+  <div class="form-group">
+    <label>Start Date: <input class="input" type="date" name="start_date" required></label>
+  </div>
+  <div class="form-group">
+    <label>End Date: <input class="input" type="date" name="end_date" required></label>
+  </div>
+  <div class="form-group">
+    <label>Location:
+      <select class="input" name="location_id">
+        <option value="all">All Locations</option>
+        {% for loc in locations %}
+          <option value="{{ loc.id }}">{{ loc.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+  </div>
+  <div class="form-group">
+    <button class="btn" type="submit">Generate</button>
+  </div>
+</form>
+{% if results %}
+<h2>Results</h2>
+<p>Average Start Time: {{ results.start_time }}</p>
+<p>Average Start Temperature: {{ results.start_temp }}°C</p>
+<p>Average End Time: {{ results.end_time }}</p>
+<p>Average End Temperature: {{ results.end_temp }}°C</p>
+{% endif %}
+{% endblock %}

--- a/templates/admin/report_missed.html
+++ b/templates/admin/report_missed.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Missed Temperatures Report</h1>
+<form method="post">
+  <div class="form-group">
+    <label>Start Date: <input class="input" type="date" name="start_date" required></label>
+  </div>
+  <div class="form-group">
+    <label>End Date: <input class="input" type="date" name="end_date" required></label>
+  </div>
+  <div class="form-group">
+    <label>Location:
+      <select class="input" name="location_id">
+        <option value="all">All Locations</option>
+        {% for loc in locations %}
+          <option value="{{ loc.id }}">{{ loc.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+  </div>
+  <div class="form-group">
+    <button class="btn" type="submit">Generate</button>
+  </div>
+</form>
+{% if total is not none %}
+<h2>Results</h2>
+<p>Total missed temps: {{ total }}</p>
+<table border="1" cellspacing="0" cellpadding="4">
+  <tr><th>Day</th><th>Missed Temps</th></tr>
+  {% for day, count in weekday_counts.items() %}
+    <tr><td>{{ day }}</td><td>{{ count }}</td></tr>
+  {% endfor %}
+</table>
+{% endif %}
+{% endblock %}

--- a/templates/cooler.html
+++ b/templates/cooler.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>{{ cooler.name }}</h1>
-{% if cooler.image_url %}
-<img src="{{ cooler.image_url }}" alt="{{ cooler.name }}" style="max-width:100%;height:auto;">
+{% if cooler.image_path %}
+<img src="{{ url_for('static', filename=cooler.image_path) }}" alt="{{ cooler.name }}" style="max-width:100%;height:auto;">
 {% endif %}
 
 <p><em>Note: temperatures are recorded in °C and may be positive or negative.</em></p>


### PR DESCRIPTION
## Summary
- Allow admins to upload cooler images stored locally
- Add average temperature report for start/end logs by date range and location
- Add missed temperature report with weekday breakdown and location filter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb3d080c48324bfc3c53ec52790a4