### PR TITLE
Add summary metrics to missed temperatures report

### DIFF
--- a/app.py
+++ b/app.py
@@ -293,6 +293,9 @@ def report_missed():
     locations = db.execute('SELECT * FROM location').fetchall()
     total = None
     weekday_counts = None
+    total_days = None
+    missed_days = None
+    percent_missed = None
     if request.method == 'POST':
         start_date = request.form.get('start_date')
         end_date = request.form.get('end_date')
@@ -315,18 +318,34 @@ def report_missed():
         existing = {(row['cooler_id'], row['d'], row['shift']) for row in logs}
         total = 0
         weekday_counts = {day: 0 for day in ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']}
+        total_days = (end_dt - start_dt).days + 1
+        missed_days_set = set()
         current = start_dt
         while current <= end_dt:
             day_name = current.strftime('%A')
             d_str = current.isoformat()
+            day_missed = False
             for cid in cooler_ids:
                 for shift in ('start', 'end'):
                     if (cid, d_str, shift) not in existing:
                         total += 1
                         weekday_counts[day_name] += 1
+                        day_missed = True
+            if day_missed:
+                missed_days_set.add(d_str)
             current += timedelta(days=1)
+        missed_days = len(missed_days_set)
+        percent_missed = (missed_days / total_days * 100) if total_days > 0 else 0
     db.close()
-    return render_template('admin/report_missed.html', locations=locations, total=total, weekday_counts=weekday_counts)
+    return render_template(
+        'admin/report_missed.html',
+        locations=locations,
+        total=total,
+        weekday_counts=weekday_counts,
+        total_days=total_days,
+        missed_days=missed_days,
+        percent_missed=percent_missed,
+    )
 
 @app.route('/admin/settings', methods=['GET', 'POST'])
 @admin_required

--- a/templates/admin/report_missed.html
+++ b/templates/admin/report_missed.html
@@ -24,6 +24,8 @@
 </form>
 {% if total is not none %}
 <h2>Results</h2>
+<p>Total days in range: {{ total_days }}</p>
+<p>Days with missed temps: {{ missed_days }} ({{ percent_missed|round(2) }}%)</p>
 <p>Total missed temps: {{ total }}</p>
 <table border="1" cellspacing="0" cellpadding="4">
   <tr><th>Day</th><th>Missed Temps</th></tr>


### PR DESCRIPTION
## Summary
- calculate total days in selected range and count days with missing readings
- compute and display percentage of days with missed temperatures alongside totals

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68afccb1d13483249e3a9e59dd6f4c15