### PR TITLE
ci: publish image only to ghcr

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,6 @@
+---
 name: Build and Push Docker Image
-on:
+'on':
   pull_request:
     types: [closed]
 
@@ -21,18 +22,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Prepare image name
         run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
-      - name: Build and push image
+      - name: Build and push image to GHCR
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: |
             ghcr.io/${{ env.IMAGE_NAME }}:latest
-            docker.io/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
- publish docker image exclusively to ghcr

## Testing
- `yamllint .github/workflows/docker-publish.yml`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be54d7d74083249977e039ef0e0577